### PR TITLE
Small config value errors, causing the settings not to be properly stored

### DIFF
--- a/etc/adminhtml/system/ingenico.xml
+++ b/etc/adminhtml/system/ingenico.xml
@@ -30,7 +30,7 @@
         <field id="order_confirmation_status" translate="label" type="select" sortOrder="45" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
             <label>Order Status which triggers an order confirmation mailing</label>
             <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
-            <config_path>payment/ingenico_e_payments/order_status</config_path>
+            <config_path>payment/ingenico_e_payments/order_confirmation_status</config_path>
             <depends>
                 <field id="payment_other/ingenico_e_payments/order_confirmation_email">3</field>
             </depends>
@@ -56,7 +56,7 @@
         </field>
         <field id="sort_order" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>ingenico.settings.label13</label>
-            <config_path>payment/ingenico_e_payments/order_status</config_path>
+            <config_path>payment/ingenico_e_payments/sort_order</config_path>
         </field>
     </group>
 </include>


### PR DESCRIPTION
We encountered the issue of some configuration values not being saved correctly, when overwriting them in the Admin.

More specifically, this caused the issue that no confirmation emails were being sent, when the trigger was set to a specific order status (to prevent the email to be sent too early in the process).

The cause of this was limited to two small typos (I assume) in the `ingenico.xml` file, for the generic settings.