### PR TITLE
Give preference to default status-state connections in `getAssignedState`

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -499,6 +499,7 @@ class Config extends \Magento\Framework\App\Config
     {
         $collection = $this->orderStatusCollectionFactory->create()->joinStates();
         $status = $collection->addAttributeToFilter('main_table.status', $status)
+                             ->addAttributeToSort('state_table.is_default', 'desc')
                              ->getFirstItem();
         return $status;
     }


### PR DESCRIPTION
We are using `status` and `state` quite intertwined through the whole process, as we allow status changes outside of the default Magento state changes. This behaviour probably is why we encountered an issue with the current behaviour of `getAssignedState`. AS it will use default sorting to get the first "hit", it was returning the unwanted state `canceled` as this happened to be one of the various possibilities of the `status`.

To mitigate this risk, it might be a good idea to give preference to `state` values, for which the provided `status` is the default value.