### PR TITLE
Fix Last_trans_id in payment model empty

### DIFF
--- a/Model/Connector.php
+++ b/Model/Connector.php
@@ -1925,15 +1925,19 @@ class Connector extends AbstractConnector implements ConnectorInterface
                 throw new \Exception('Order doesn\'t exists in store');
             }
 
+            $payment = $order->getPayment();
+
             // Register Magento Transaction
-            $order->getPayment()->setTransactionId($data->getPayId() . '-' . $data->getPayIdSub());
+            $payment->setTransactionId($data->getPayId() . '-' . $data->getPayIdSub());
 
             /** @var \Magento\Sales\Model\Order\Payment\Transaction $transaction */
-            $transaction = $order->getPayment()->addTransaction($trxType, null, true);
+            $transaction = $payment->addTransaction($trxType, null, true);
             $transaction
                 ->setIsClosed(0)
                 ->setAdditionalInformation(Transaction::RAW_DETAILS, $data->getData())
                 ->save();
+
+            $payment->save();
         }
 
         return true;

--- a/Model/Connector.php
+++ b/Model/Connector.php
@@ -1253,8 +1253,11 @@ class Connector extends AbstractConnector implements ConnectorInterface
         try {
             $order = $this->processor->getOrderByIncrementId($orderId);
             $method = $order->getPayment()->getMethodInstance();
-
-            return $method::CORE_CODE;
+            if ($method instanceof AbstractMethod) {
+                return $method::CORE_CODE;
+            } else {
+                return $method->getCode();
+            }
         } catch (\Exception $exception) {
             return false;
         }
@@ -1278,7 +1281,11 @@ class Connector extends AbstractConnector implements ConnectorInterface
 
             $method = $quote->getPayment()->getMethodInstance();
 
-            return $method::CORE_CODE;
+            if ($method instanceof AbstractMethod) {
+                return $method::CORE_CODE;
+            } else {
+                return $method->getCode();
+            }
         } catch (\Exception $exception) {
             return false;
         }

--- a/Model/Connector.php
+++ b/Model/Connector.php
@@ -1255,9 +1255,8 @@ class Connector extends AbstractConnector implements ConnectorInterface
             $method = $order->getPayment()->getMethodInstance();
             if ($method instanceof AbstractMethod) {
                 return $method::CORE_CODE;
-            } else {
-                return $method->getCode();
             }
+            return $method->getCode();
         } catch (\Exception $exception) {
             return false;
         }
@@ -1283,9 +1282,8 @@ class Connector extends AbstractConnector implements ConnectorInterface
 
             if ($method instanceof AbstractMethod) {
                 return $method::CORE_CODE;
-            } else {
-                return $method->getCode();
             }
+            return $method->getCode();
         } catch (\Exception $exception) {
             return false;
         }


### PR DESCRIPTION
Information about the last succesfull transaction was not persisted on the payment. For example `last_trans_id`.