### PR TITLE
Correctly fetch the order locale based on the order store id

### DIFF
--- a/Model/Connector.php
+++ b/Model/Connector.php
@@ -1432,17 +1432,14 @@ class Connector extends AbstractConnector implements ConnectorInterface
      */
     public function getLocale($orderId = null)
     {
-        $currentStoreId = $this->storeManager->getStore()->getId();
-        $locale = $this->localeResolver->getLocale();
-
-        if ($orderId) {
-            $order = $this->processor->getOrderByIncrementId($orderId);
-            $orderStoreId = $order->getStoreId();
-            if ($currentStoreId !== $orderStoreId) {
-                $locale = $this->localeResolver->emulate($orderStoreId);
-                $this->localeResolver->revert();
-            }
+        if (!$orderId) {
+            return $this->localeResolver->getLocale();
         }
+        
+        $order = $this->processor->getOrderByIncrementId($orderId);
+        $orderStoreId = $order->getStoreId();
+        $locale = $this->localeResolver->emulate($orderStoreId);
+        $this->localeResolver->revert();
 
         return $locale;
     }


### PR DESCRIPTION
Currently localeResolver getLocale function is used to fetch the store locale but this function will always fetch the default locale.
But the storeManager will return the correct store id. Therefor the if statement will always return false and never fetch the correct order locale.

This PR fixes this.